### PR TITLE
Handle NULL:s and clarify REAL vs FLOAT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+
+.vscode

--- a/v2/conn_integration_test.go
+++ b/v2/conn_integration_test.go
@@ -234,8 +234,14 @@ func TestConnTimezoneIntegration(t *testing.T) {
 		default:
 			mytime := time.Now()
 			_, offset := mytime.Local().Zone()
+
 			if offset != secondsEastOfUTC {
-				t.Errorf("Offset mismatch: expected %d (local), got %d (from db)", offset, secondsEastOfUTC)
+
+				// MonetDB might be running with explicit UTC timezone (even if the host uses a different tz)
+				if secondsEastOfUTC != 0 {
+					t.Errorf("Offset mismatch: expected %d (local), got %d (from db)", offset, secondsEastOfUTC)
+				}
+
 			}
 		}
 	})

--- a/v2/conn_integration_test.go
+++ b/v2/conn_integration_test.go
@@ -236,12 +236,10 @@ func TestConnTimezoneIntegration(t *testing.T) {
 			_, offset := mytime.Local().Zone()
 
 			if offset != secondsEastOfUTC {
-
-				// MonetDB might be running with explicit UTC timezone (even if the host uses a different tz)
+				// MonetDB Mar2025 defaults to UTC offset (used to be host machine tz offset)
 				if secondsEastOfUTC != 0 {
 					t.Errorf("Offset mismatch: expected %d (local), got %d (from db)", offset, secondsEastOfUTC)
 				}
-
 			}
 		}
 	})

--- a/v2/conn_integration_test.go
+++ b/v2/conn_integration_test.go
@@ -104,7 +104,7 @@ func TestConnSerialIntegration(t *testing.T) {
 	})
 
 	t.Run("insert statement", func(t *testing.T) {
-		result, err := db.Exec("insert into test3 ( name ) values ( 'name' )" )
+		result, err := db.Exec("insert into test3 ( name ) values ( 'name' )")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -139,7 +139,7 @@ func TestConnSerialIntegration(t *testing.T) {
 			var id int
 			var name string
 			if err := rows.Scan(&id, &name); err != nil {
-			 t.Error(err)
+				t.Error(err)
 			}
 		}
 		if err := rows.Err(); err != nil {
@@ -180,7 +180,7 @@ func TestConnTimezoneIntegration(t *testing.T) {
 	})
 
 	t.Run("insert statement", func(t *testing.T) {
-		result, err := db.Exec("insert into test3 ( sometime ) values ( '2024-01-19 09:54:30.988417434+0000' )" )
+		result, err := db.Exec("insert into test3 ( sometime ) values ( '2024-01-19 09:54:30.988417434+0000' )")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -214,7 +214,7 @@ func TestConnTimezoneIntegration(t *testing.T) {
 		for rows.Next() {
 			var sometime time.Time
 			if err := rows.Scan(&sometime); err != nil {
-			 t.Error(err)
+				t.Error(err)
 			}
 		}
 		if err := rows.Err(); err != nil {
@@ -235,7 +235,7 @@ func TestConnTimezoneIntegration(t *testing.T) {
 			mytime := time.Now()
 			_, offset := mytime.Local().Zone()
 			if offset != secondsEastOfUTC {
-				t.Error("Offset is not the same as the database timezone")
+				t.Errorf("Offset mismatch: expected %d (local), got %d (from db)", offset, secondsEastOfUTC)
 			}
 		}
 	})

--- a/v2/mapi/converter.go
+++ b/v2/mapi/converter.go
@@ -47,17 +47,17 @@ const (
 
 	// full names and aliases, spaces are replaced with underscores
 	//lint:ignore U1000 prepare to enable staticchecks
-	mdb_CHARACTER               = MDB_CHAR
+	mdb_CHARACTER = MDB_CHAR
 	//lint:ignore U1000 prepare to enable staticchecks
-	mdb_CHARACTER_VARYING       = MDB_VARCHAR
+	mdb_CHARACTER_VARYING = MDB_VARCHAR
 	//lint:ignore U1000 prepare to enable staticchecks
 	mdb_CHARACHTER_LARGE_OBJECT = MDB_CLOB
 	//lint:ignore U1000 prepare to enable staticchecks
-	mdb_BINARY_LARGE_OBJECT     = MDB_BLOB
+	mdb_BINARY_LARGE_OBJECT = MDB_BLOB
 	//lint:ignore U1000 prepare to enable staticchecks
-	mdb_NUMERIC                 = MDB_DECIMAL
+	mdb_NUMERIC = MDB_DECIMAL
 	//lint:ignore U1000 prepare to enable staticchecks
-	mdb_DOUBLE_PRECISION        = MDB_DOUBLE
+	mdb_DOUBLE_PRECISION = MDB_DOUBLE
 )
 
 var timeFormats = []string{
@@ -67,6 +67,7 @@ var timeFormats = []string{
 	"2006-01-02 15:04:05 -0700 MST",
 	"Mon Jan 2 15:04:05 -0700 MST 2006",
 	"2006-01-02 15:04:05.999999+00:00",
+	"2006-01-02 15:04:05.999999-07:00",
 	"15:04:05",
 }
 
@@ -277,20 +278,20 @@ func toDateTimeString(v Value) (string, error) {
 }
 
 var toMonetMappers = map[string]toMonetConverter{
-	"int":          toString,
-	"int8":         toString,
-	"int16":        toString,
-	"int32":        toString,
-	"int64":        toString,
-	"float":        toString,
-	"float32":      toString,
-	"float64":      toString,
-	"bool":         toString,
-	"string":       toQuotedString,
-	"nil":          toNull,
-	"null":         toNull,
-	"[]uint8":      toByteString,
-	"time.Time":    toQuotedString,
+	"int":       toString,
+	"int8":      toString,
+	"int16":     toString,
+	"int32":     toString,
+	"int64":     toString,
+	"float":     toString,
+	"float32":   toString,
+	"float64":   toString,
+	"bool":      toString,
+	"string":    toQuotedString,
+	"nil":       toNull,
+	"null":      toNull,
+	"[]uint8":   toByteString,
+	"time.Time": toQuotedString,
 	"mapi.Time": toDateTimeString,
 	"mapi.Date": toDateTimeString,
 }

--- a/v2/mapi/converter.go
+++ b/v2/mapi/converter.go
@@ -181,7 +181,7 @@ func parseTime(v string) (t time.Time, err error) {
 }
 
 func toNil(v string) (Value, error) {
-	return "NULL", nil
+	return nil, nil
 }
 
 func toBool(v string) (Value, error) {
@@ -297,8 +297,8 @@ var toMonetMappers = map[string]toMonetConverter{
 }
 
 func convertToGo(value, dataType string) (Value, error) {
-	if strings.TrimSpace(value) == "NULL" {
-		dataType = "NULL"
+	if strings.TrimSpace(value) == MDB_NULL {
+		dataType = MDB_NULL
 	}
 
 	if mapper, ok := toGoMappers[dataType]; ok {

--- a/v2/mapi/converter.go
+++ b/v2/mapi/converter.go
@@ -123,6 +123,15 @@ func toDouble(v string) (Value, error) {
 	return strconv.ParseFloat(v, 64)
 }
 
+func toReal(v string) (Value, error) {
+	var r float32
+	i, err := strconv.ParseFloat(v, 32)
+	if err == nil {
+		r = float32(i)
+	}
+	return r, err
+}
+
 func toInt8(v string) (Value, error) {
 	var r int8
 	i, err := strconv.ParseInt(v, 10, 8)
@@ -216,8 +225,9 @@ var toGoMappers = map[string]toGoConverter{
 	MDB_BIGINT:         toInt64,
 	MDB_HUGEINT:        toInt64,
 	MDB_SERIAL:         toInt64,
-	MDB_REAL:           toDouble, //  map REAL (Float32) to Float64 to avoid issues with nullability
+	MDB_REAL:           toReal,
 	MDB_DOUBLE:         toDouble,
+	MDB_FLOAT:          toDouble,
 	MDB_BOOLEAN:        toBool,
 	MDB_DATE:           toDate,
 	MDB_TIME:           toTime,
@@ -230,7 +240,6 @@ var toGoMappers = map[string]toGoConverter{
 	MDB_SHORTINT:       toInt16,
 	MDB_MEDIUMINT:      toInt32,
 	MDB_LONGINT:        toInt64,
-	MDB_FLOAT:          toDouble,
 }
 
 func toString(v Value) (string, error) {

--- a/v2/mapi/converter_test.go
+++ b/v2/mapi/converter_test.go
@@ -6,6 +6,7 @@ package mapi
 
 import (
 	"bytes"
+	"database/sql"
 	"testing"
 	"time"
 )
@@ -64,8 +65,8 @@ func TestConvertToGo(t *testing.T) {
 		{"64", "longint", int64(64)},
 		{"64", "hugeint", int64(64)},
 		{"64", "serial", int64(64)},
-		{"3.2", "float", float32(3.2)},
-		{"3.2", "real", float32(3.2)},
+		{"3.2", "float", sql.NullFloat64{Float64: 3.2, Valid: true}}, // float and real are nullable
+		{"3.2", "real", sql.NullFloat64{Float64: 3.2, Valid: true}},
 		{"6.4", "double", float64(6.4)},
 		{"6.4", "decimal", float64(6.4)},
 		{"true", "boolean", true},

--- a/v2/mapi/converter_test.go
+++ b/v2/mapi/converter_test.go
@@ -65,7 +65,7 @@ func TestConvertToGo(t *testing.T) {
 		{"64", "hugeint", int64(64)},
 		{"64", "serial", int64(64)},
 		{"3.2", "float", float64(3.2)},
-		{"3.2", "real", float64(3.2)}, // REAL is mapped to float64
+		{"3.2", "real", float32(3.2)},
 		{"6.4", "double", float64(6.4)},
 		{"6.4", "decimal", float64(6.4)},
 		{"true", "boolean", true},
@@ -80,6 +80,8 @@ func TestConvertToGo(t *testing.T) {
 		{"'back\\\\slashed'", "char", "back\\slashed"},
 		{"'ABC'", "blob", []uint8{0x41, 0x42, 0x43}},
 		{"NULL", "varchar", nil},
+		{"NULL", "float32", nil},
+		{"NULL", "float64", nil},
 	}
 
 	for _, c := range tcs {

--- a/v2/mapi/converter_test.go
+++ b/v2/mapi/converter_test.go
@@ -79,6 +79,7 @@ func TestConvertToGo(t *testing.T) {
 		{"'quoted \\\\\\'string\\\\\\''", "char", "quoted \\'string\\'"},
 		{"'back\\\\slashed'", "char", "back\\slashed"},
 		{"'ABC'", "blob", []uint8{0x41, 0x42, 0x43}},
+		{"NULL", "varchar", nil},
 	}
 
 	for _, c := range tcs {

--- a/v2/mapi/converter_test.go
+++ b/v2/mapi/converter_test.go
@@ -6,7 +6,6 @@ package mapi
 
 import (
 	"bytes"
-	"database/sql"
 	"testing"
 	"time"
 )
@@ -65,8 +64,8 @@ func TestConvertToGo(t *testing.T) {
 		{"64", "longint", int64(64)},
 		{"64", "hugeint", int64(64)},
 		{"64", "serial", int64(64)},
-		{"3.2", "float", sql.NullFloat64{Float64: 3.2, Valid: true}}, // float and real are nullable
-		{"3.2", "real", sql.NullFloat64{Float64: 3.2, Valid: true}},
+		{"3.2", "float", float64(3.2)},
+		{"3.2", "real", float64(3.2)}, // REAL is mapped to float64
 		{"6.4", "double", float64(6.4)},
 		{"6.4", "decimal", float64(6.4)},
 		{"true", "boolean", true},

--- a/v2/param_integration_test.go
+++ b/v2/param_integration_test.go
@@ -1,14 +1,14 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. 
-*/
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package monetdb
 
 import (
 	"database/sql"
 	"testing"
 )
- 
+
 func TestParamIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
@@ -78,7 +78,7 @@ func TestParamIntegration(t *testing.T) {
 
 	t.Run("Get Columns", func(t *testing.T) {
 		// Be careful, a named placeholder starts with a colon but does not end with one
-		rows, err := db.Query("select * from test1 where name = :name", sql.Named("name", "name1"))
+		rows, err := db.Query("select * from test1 where name = :name_", sql.Named("name_", "name1"))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -87,7 +87,7 @@ func TestParamIntegration(t *testing.T) {
 		if rows == nil {
 			t.Fatal("empty result")
 		}
-		columnlist, err  := rows.Columns()
+		columnlist, err := rows.Columns()
 		if err != nil {
 			t.Error(err)
 		}
@@ -99,7 +99,7 @@ func TestParamIntegration(t *testing.T) {
 		for rows.Next() {
 			var name string
 			if err := rows.Scan(&name); err != nil {
-			 t.Error(err)
+				t.Error(err)
 			}
 		}
 		if err := rows.Err(); err != nil {
@@ -183,7 +183,7 @@ func TestIntParamIntegration(t *testing.T) {
 	})
 
 	t.Run("Get Columns", func(t *testing.T) {
-		rows, err := db.Query("select * from test1 where name = :name", sql.Named("name", 16))
+		rows, err := db.Query("select * from test1 where name = :name_", sql.Named("name_", 16))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -192,7 +192,7 @@ func TestIntParamIntegration(t *testing.T) {
 		if rows == nil {
 			t.Fatal("empty result")
 		}
-		columnlist, err  := rows.Columns()
+		columnlist, err := rows.Columns()
 		if err != nil {
 			t.Error(err)
 		}
@@ -204,7 +204,7 @@ func TestIntParamIntegration(t *testing.T) {
 		for rows.Next() {
 			var name int
 			if err := rows.Scan(&name); err != nil {
-			 t.Error(err)
+				t.Error(err)
 			}
 		}
 		if err := rows.Err(); err != nil {
@@ -289,7 +289,7 @@ func TestMultipleParamIntegration(t *testing.T) {
 	})
 
 	t.Run("Get Columns", func(t *testing.T) {
-		rows, err := db.Query("select * from test1 where name = :name and value = :value", sql.Named("name", "name1"), sql.Named("value", 16))
+		rows, err := db.Query("select * from test1 where name = :name_ and value = :value_", sql.Named("name_", "name1"), sql.Named("value_", 16))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -298,7 +298,7 @@ func TestMultipleParamIntegration(t *testing.T) {
 		if rows == nil {
 			t.Fatal("empty result")
 		}
-		columnlist, err  := rows.Columns()
+		columnlist, err := rows.Columns()
 		if err != nil {
 			t.Error(err)
 		}

--- a/v2/rows.go
+++ b/v2/rows.go
@@ -197,11 +197,11 @@ func (r *Rows) ColumnTypeScanType(index int) reflect.Type {
 		scantype = reflect.TypeOf([]uint8{0})
 	case mapi.MDB_BOOLEAN:
 		scantype = reflect.TypeOf(true)
-	case mapi.MDB_REAL,
-		mapi.MDB_FLOAT:
-		scantype = reflect.TypeOf(float64(0))
+	case mapi.MDB_REAL:
+		scantype = reflect.TypeOf(float32(0))
 	case mapi.MDB_DECIMAL,
-		mapi.MDB_DOUBLE:
+		mapi.MDB_DOUBLE,
+		mapi.MDB_FLOAT:
 		scantype = reflect.TypeOf(float64(0))
 	case mapi.MDB_TINYINT:
 		scantype = reflect.TypeOf(int8(0))

--- a/v2/rows_integration_test.go
+++ b/v2/rows_integration_test.go
@@ -10,7 +10,7 @@ import (
 	"math"
 	"testing"
 )
- 
+
 func TestRowsIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
@@ -100,7 +100,7 @@ func TestRowsIntegration(t *testing.T) {
 		if rows == nil {
 			t.Fatal("empty result")
 		}
-		columnlist, err  := rows.Columns()
+		columnlist, err := rows.Columns()
 		if err != nil {
 			t.Error(err)
 		}
@@ -112,7 +112,7 @@ func TestRowsIntegration(t *testing.T) {
 		for rows.Next() {
 			var name string
 			if err := rows.Scan(&name); err != nil {
-			 t.Error(err)
+				t.Error(err)
 			}
 		}
 		if err := rows.Err(); err != nil {
@@ -148,7 +148,6 @@ func TestRowsIntegration(t *testing.T) {
 	defer db.Close()
 }
 
-
 func TestColumnTypesIntegration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
@@ -163,9 +162,9 @@ func TestColumnTypesIntegration(t *testing.T) {
 	}
 
 	type coltypetest struct {
-		ct    string // create table query
-		it    string // insert into query
-		cs    string // select star query
+		ct  string   // create table query
+		it  string   // insert into query
+		cs  string   // select star query
 		cn  []string // column names
 		lok []bool   // length value available
 		cl  []int64  // column lengths
@@ -175,7 +174,7 @@ func TestColumnTypesIntegration(t *testing.T) {
 		ds  []bool   // decimal size available
 		dsp []int64  // decimal precision
 		dss []int64  // decimal scale
-		dt   string  // drop table query
+		dt  string   // drop table query
 	}
 
 	var ctl = []coltypetest{
@@ -263,7 +262,7 @@ func TestColumnTypesIntegration(t *testing.T) {
 			[]int64{0, 0},
 			[]bool{false, false},
 			[]string{"REAL", "BOOLEAN"},
-			[]string{"float32", "bool"},
+			[]string{"float64", "bool"},
 			[]bool{false, false},
 			[]int64{0, 0},
 			[]int64{0, 0},
@@ -339,16 +338,16 @@ func TestColumnTypesIntegration(t *testing.T) {
 			if rows == nil {
 				t.Fatal("empty result")
 			}
-			columnlist, err  := rows.Columns()
+			columnlist, err := rows.Columns()
 			if err != nil {
 				t.Error(err)
 			}
 			for j, column := range columnlist {
-				if column !=  ctl[i].cn[j]{
+				if column != ctl[i].cn[j] {
 					t.Errorf("unexpected column name in Columns: %s", column)
 				}
 			}
-			columntypes, err  := rows.ColumnTypes()
+			columntypes, err := rows.ColumnTypes()
 			if err != nil {
 				t.Error(err)
 			}
@@ -367,7 +366,7 @@ func TestColumnTypesIntegration(t *testing.T) {
 					}
 				}
 				_, nullable_ok := column.Nullable()
-				if nullable_ok != ctl[i].nok[j]{
+				if nullable_ok != ctl[i].nok[j] {
 					t.Errorf("not expected that nullable was provided")
 				}
 				coltype := column.DatabaseTypeName()
@@ -386,7 +385,7 @@ func TestColumnTypesIntegration(t *testing.T) {
 					}
 				}
 				precision, scale, ok := column.DecimalSize()
-				if ok != ctl[i].ds[j]{
+				if ok != ctl[i].ds[j] {
 					t.Errorf("not expected that decimal size was provided")
 				} else {
 					if ok {
@@ -400,15 +399,15 @@ func TestColumnTypesIntegration(t *testing.T) {
 				}
 			}
 			/*
-			for rows.Next() {
-				name := make([]driver.Value, colcount)
-				if err := rows.Scan(&name); err != nil {
-				t.Error(err)
+				for rows.Next() {
+					name := make([]driver.Value, colcount)
+					if err := rows.Scan(&name); err != nil {
+					t.Error(err)
+					}
 				}
-			}
-			if err := rows.Err(); err != nil {
-				t.Error(err)
-			}
+				if err := rows.Err(); err != nil {
+					t.Error(err)
+				}
 			*/
 			defer rows.Close()
 		})

--- a/v2/rows_integration_test.go
+++ b/v2/rows_integration_test.go
@@ -262,7 +262,7 @@ func TestColumnTypesIntegration(t *testing.T) {
 			[]int64{0, 0},
 			[]bool{false, false},
 			[]string{"REAL", "BOOLEAN"},
-			[]string{"float64", "bool"},
+			[]string{"float32", "bool"},
 			[]bool{false, false},
 			[]int64{0, 0},
 			[]int64{0, 0},


### PR DESCRIPTION
Some minor fixes, noticed when using the Grafana data source at https://github.com/dataspex/dataspex-monetdb-grafana-datasource

* Fixed bug in function `convertNil` (return `nil` instead of literal `"NULL"`)
* Clarify that `FLOAT` is `float64` and `REAL` is `float32`
* Avoid using `name` and  `value` as parameter names (breaks in MonetDB Mar2025)
* Fix test that assumes MonetDB uses local tz offset

Some additional formatting changes were applied to the files that were modified.
The version number should also be increased (from `v2.0.2`), not sure how this is handled (apparently via a git tag?).